### PR TITLE
Add menu options for both versions

### DIFF
--- a/pinokio.js
+++ b/pinokio.js
@@ -67,8 +67,12 @@ module.exports = {
         return [{
           default: true,
           icon: "fa-solid fa-power-off",
-          text: "Start",
+          text: "Start FramePack",
           href: "start.js",
+        }, {
+          icon: "fa-solid fa-power-off",
+          text: "Start FramePack-F1",
+          href: "start.js?version=f1",
         }, {
           icon: "fa-solid fa-plug",
           text: "Update",
@@ -86,7 +90,6 @@ module.exports = {
           text: "<div><strong>Reset</strong><div>Revert to pre-install state</div></div>",
           href: "reset.js",
           confirm: "Are you sure you wish to reset the app?"
-
         }]
       }
     } else {

--- a/start.js
+++ b/start.js
@@ -1,5 +1,9 @@
 module.exports = async (kernel) => {
   const port = await kernel.port()
+  // Check if we're starting the F1 version
+  const isF1 = kernel.params && kernel.params.version === "f1"
+  const scriptToRun = isF1 ? "demo_gradio_f1.py" : "demo_gradio.py"
+  
   return {
     daemon: true,
     run: [
@@ -10,7 +14,7 @@ module.exports = async (kernel) => {
           env: { },                   // Edit this to customize environment variables (see documentation)
           path: "app",                // Edit this to customize the path to start the shell from
           message: [
-            `python demo_gradio.py --server 127.0.0.1 --port ${port}`,    // Edit with your custom commands
+            `python ${scriptToRun} --server 127.0.0.1 --port ${port}`,    // Edit with your custom commands
           ],
           on: [{
             // The regular expression pattern to monitor.


### PR DESCRIPTION
## Added:
- Option to choose between running the original version or F1 version from the Pinokio menu
- Parameterization of start.js to support both scripts